### PR TITLE
cepheus: revert white UDFPS color to fix UDFPS recognition

### DIFF
--- a/rro_overlays/LineageSystemUIOverlayDevice/res/values/lineage_config.xml
+++ b/rro_overlays/LineageSystemUIOverlayDevice/res/values/lineage_config.xml
@@ -5,5 +5,5 @@
 -->
 <resources>
     <!-- Color of the UDFPS pressed view -->
-    <color name="config_udfpsColor">#ffffff</color>
+    <color name="config_udfpsColor">#00ff00</color>
 </resources>


### PR DESCRIPTION
white color breaks UDFPS